### PR TITLE
Fix Click migration regressions, drop unused `docs`, add `meta rec`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,12 +25,9 @@ Dependencies
 - `meta <https://github.com/xray-imaging/meta.git>`_
 - scikit-build
 - click
-- dxchange
 - h5py
 - numpy
 - pandas
-- scipy
-- tabulate
 
 Usage
 =====
@@ -81,38 +78,6 @@ To replace the value of an entry:
  ::
 
     $ meta set --file-name data/base_file_name_001.h5 --key /process/acquisition/rotation/rotation_start --value 10
-
-
-Meta data rst table
--------------------
-
-To generate a meta data rst table compatible with sphinx/readthedocs::
-
-    $ meta docs --file-name data/base_file_name_001.h5 
-    2022-02-09 12:30:16,983 - Please copy/paste the content of ./log_2020-05.rst in your rst docs file
-
-
-The content of the generated rst file will publish in a sphinx/readthedocs document as:
-
-**2022-05**
-
-**decarlo**
-
-+--------------------------------------------------------+--------------------+--------+
-|                                                        | value              | unit   |
-+========================================================+====================+========+
-| 000_/measurement/instrument/monochromator/energy       | 30.0               | keV    |
-+--------------------------------------------------------+--------------------+--------+
-| 000_/measurement/instrument/sample_motor_stack/setup/x | 0.0                | mm     |
-+--------------------------------------------------------+--------------------+--------+
-| 000_/measurement/instrument/sample_motor_stack/setup/y | 0.4000116247000278 | mm     |
-+--------------------------------------------------------+--------------------+--------+
-| 000_/measurement/sample/experimenter/email             | decarlof@gmail.com |        |
-+--------------------------------------------------------+--------------------+--------+
-
-
-.. note:: 
-	when using the **docs** option --file-name can be also a folder, e.g. --file-name data/ in this case all hdf files in the folder will be processed.
 
 
 to list of all available options::

--- a/envs/requirements.txt
+++ b/envs/requirements.txt
@@ -1,8 +1,5 @@
 scikit-build
 click
-dxchange
 h5py
 numpy
 pandas
-scipy
-tabulate

--- a/src/meta_cli/__main__.py
+++ b/src/meta_cli/__main__.py
@@ -110,14 +110,6 @@ def tree(file_name):
     for entry in tree:
         log.info(entry)
 
-@cli.command()
-@click.option('--file-name', default='.', help="An hdf5 file, e.g. /data/sample.h5")
-def docs(file_name):
-    """Create in --doc-dir an rst file compatible with sphinx/readthedocs containing 
-    the DataExchange hdf file meta data
-    """
-    utils.create_rst_file(file_name)
-
 def main():
     home = os.path.expanduser("~")
     logs_home = home + '/logs/'

--- a/src/meta_cli/__main__.py
+++ b/src/meta_cli/__main__.py
@@ -20,15 +20,17 @@ from datetime import datetime
 from meta_cli import log
 from meta_cli import utils
 
-@click.group()
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
+@click.group(context_settings=CONTEXT_SETTINGS)
 def cli():
     pass
 
-@cli.command()
-@click.option('--file-name', default='.', help="An hdf5 file or directory containing multiple hdf5 files, e.g. /data/sample.h5 or /data/")
+@cli.command(context_settings=CONTEXT_SETTINGS)
+@click.option('--path', '--file-name', 'file_name', default='.', help="An hdf5 file or a directory containing multiple hdf5 files, e.g. /data/sample.h5 or /data/")
 @click.option('--key', default='', help="When set only tags containing key are shown")
 def show(file_name, key):
-    """Show meta data extracted from --file-name"""
+    """Show meta data extracted from --file-name / --path"""
     errors = 0
     file_path = pathlib.Path(file_name)
     if file_path.is_file():
@@ -45,7 +47,7 @@ def show(file_name, key):
             log.error("Found %d PVs listed has having valid units but containing a NaN value. The EPICS IOC associted with these PVs was not running during data collections." % errors)
     elif file_path.is_dir():
         log.info("publishing a multiple files in: %s" % file_name)
-        top = os.path.join(args.file_name, '')
+        top = os.path.join(file_name, '')
         h5_file_list = list(filter(lambda x: x.endswith(('.h5', '.hdf', 'hdf5')), os.listdir(top)))
         h5_file_list_sorted = sorted(h5_file_list, key = lambda x: x.split('_')[-1])
         if (h5_file_list):
@@ -73,7 +75,7 @@ def show(file_name, key):
     else:
         log.error("directory or file name does not exist: %s" % file_name)
 
-@cli.command()
+@cli.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--file-name', default='.', help="An hdf5 file, e.g. /data/sample.h5")
 @click.option('--key', default='', help="Key entry to be modified")
 @click.option('--value', default=None, help="Value to replace the original key entry")
@@ -81,6 +83,9 @@ def set(file_name):
     """Set the meta data value of a --key from an hdf file --file-name"""
 
     file_path = pathlib.Path(file_name)
+    if file_path.is_dir():
+        log.warning("--file-name %s is a directory; set only accepts a single hdf5 file" % file_name)
+        return
     if file_path.is_file():
         mp = meta.read_meta.Hdf5MetadataReader(file_name)
         meta_dict = mp.readMetadata()
@@ -102,10 +107,17 @@ def set(file_name):
         log.error("file %s does not exist" % file_name)
 
 
-@cli.command()
+@cli.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--file-name', default='.', help="An hdf5 file, e.g. /data/sample.h5")
 def tree(file_name):
     """Show meta data tree extracted from --file-name"""
+    file_path = pathlib.Path(file_name)
+    if file_path.is_dir():
+        log.warning("--file-name %s is a directory; tree only accepts a single hdf5 file" % file_name)
+        return
+    if not file_path.is_file():
+        log.error("file %s does not exist" % file_name)
+        return
     tree = meta.get_hdf_tree(file_name, display=False)
     for entry in tree:
         log.info(entry)

--- a/src/meta_cli/__main__.py
+++ b/src/meta_cli/__main__.py
@@ -11,8 +11,9 @@
 import re
 import os
 import sys
-import pathlib 
+import pathlib
 import meta
+import h5py
 import click
 
 from datetime import datetime
@@ -121,6 +122,57 @@ def tree(file_name):
     tree = meta.get_hdf_tree(file_name, display=False)
     for entry in tree:
         log.info(entry)
+
+def _rec_one(file_name, save):
+    """Print the tomocupy 'command' attribute of /exchange/data for one file;
+    optionally write a <basename>_line.txt sidecar. Skips (with a warning) any
+    file that is not a tomocupy rec file."""
+    try:
+        with h5py.File(file_name, 'r') as f:
+            if '/exchange/data' not in f:
+                log.error("%s has no /exchange/data dataset" % file_name)
+                return
+            attrs = f['/exchange/data'].attrs
+            if 'command' not in attrs:
+                log.warning("%s has no 'command' attribute on /exchange/data (raw file, or a rec file that pre-dates the attribute)" % file_name)
+                return
+            cmd = attrs['command']
+            if isinstance(cmd, bytes):
+                cmd = cmd.decode('utf-8', errors='replace')
+            cmd = str(cmd).rstrip('\x00').strip()
+    except OSError as e:
+        log.error("Failed to open %s: %s" % (file_name, e))
+        return
+
+    print(cmd)
+
+    if save:
+        stem = str(file_name)
+        sidecar = (stem[:-3] if stem.endswith('.h5') else stem) + '_line.txt'
+        with open(sidecar, 'w') as fh:
+            fh.write(cmd + '\n')
+        log.info("wrote %s" % sidecar)
+
+
+@cli.command(context_settings=CONTEXT_SETTINGS)
+@click.option('--path', '--file-name', 'file_name', default='.', help="A tomocupy _rec.h5 file or a directory containing multiple hdf5 files, e.g. /data/sample_rec.h5 or /data/")
+@click.option('--save', is_flag=True, help="Also write a sidecar <basename>_line.txt next to each input file")
+def rec(file_name, save):
+    """Show the tomocupy command that was used to generate a --file-name / --path _rec.h5 file"""
+    file_path = pathlib.Path(file_name)
+    if file_path.is_file():
+        _rec_one(file_name, save)
+    elif file_path.is_dir():
+        top = os.path.join(file_name, '')
+        h5_file_list = sorted(filter(lambda x: x.endswith(('.h5', '.hdf', '.hdf5')), os.listdir(top)))
+        if not h5_file_list:
+            log.error("directory %s does not contain any hdf5 file" % file_name)
+            return
+        for fname in h5_file_list:
+            log.warning("  *** %s" % fname)
+            _rec_one(top + fname, save)
+    else:
+        log.error("file or directory %s does not exist" % file_name)
 
 def main():
     home = os.path.expanduser("~")

--- a/src/meta_cli/__main__.py
+++ b/src/meta_cli/__main__.py
@@ -78,8 +78,8 @@ def show(file_name, key):
 @cli.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--file-name', default='.', help="An hdf5 file, e.g. /data/sample.h5")
 @click.option('--key', default='', help="Key entry to be modified")
-@click.option('--value', default=None, help="Value to replace the original key entry")
-def set(file_name):
+@click.option('--value', default=None, type=float, help="Value to replace the original key entry")
+def set(file_name, key, value):
     """Set the meta data value of a --key from an hdf file --file-name"""
 
     file_path = pathlib.Path(file_name)

--- a/src/meta_cli/utils.py
+++ b/src/meta_cli/utils.py
@@ -43,13 +43,8 @@
 # POSSIBILITY OF SUCH DAMAGE.                                             #
 # #########################################################################
 
-import os
 import h5py
-import meta
-import datetime
-import pathlib 
 import numpy as np
-import pandas as pd
 from meta_cli import log
 
 class bcolors:
@@ -63,122 +58,6 @@ class bcolors:
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
 
-
-def add_header(label):
-
-    header = add_decorator(label) + '\n' + label + '\n' + add_decorator(label) + '\n\n'
-
-    return header
-
-def add_title(label):
-
-    title = label + '\n' + add_decorator(label, decorator='-') + '\n\n' 
-
-    return title
-
-
-def add_decorator(label, decorator='='):
-    
-    return decorator.replace(decorator, decorator*len(label))
-
-def create_rst_file(file_name):
-    
-    meta_data, year_month, pi_name = extract_rst_meta(file_name)
-
-    decorator = '='
-    log_fname = os.path.join(str(pathlib.Path.home()), 'log_' + year_month + '.rst')
-
-    with open(log_fname, 'a') as f:
-        if f.tell() == 0:
-            # a new file or the file was empty
-            f.write(add_header(year_month))
-            f.write(add_title(pi_name))
-        else:
-            #  file existed, appending
-            f.write(add_title(pi_name))
-        f.write('\n')        
-        f.write(meta_data)        
-        f.write('\n\n')        
-    log.warning('Please copy/paste the content of %s in your rst docs file' % (log_fname))
-
-def extract_rst_meta(fname):
-
-    # Customize this list to add more meta_data in the rst table.
-    # To see the full list of available meta_data run:
-    # meta show --file-name myfile.h5
-    list_to_extract = ('/measurement/instrument/monochromator/energy', 
-                    '/measurement/sample/experimenter/email',
-                    '/measurement/instrument/sample_motor_stack/setup/x', 
-                    '/measurement/instrument/sample_motor_stack/setup/y'
-                    )
-
-    # set pandas display
-    pd.options.display.max_rows = 999
-    year_month = 'unknown'
-    pi_name    = 'unknown'
-
-    if os.path.isfile(fname): 
-        meta_dict, year_month, pi_name = extract_dict(fname, list_to_extract)
-        # print (meta_dict, year_month, pi_name)
-        # exit()
-    elif os.path.isdir(fname):
-        # Add a trailing slash if missing
-        top = os.path.join(fname, '')
-        # Set the file name that will store the rotation axis positions.
-        h5_file_list = list(filter(lambda x: x.endswith(('.h5', '.hdf')), os.listdir(top)))
-        h5_file_list.sort()
-        meta_dict = {}
-        file_counter=0
-        for fname in h5_file_list:
-            h5fname = top + fname
-            sub_dict, year_month, pi_name = extract_dict(h5fname, list_to_extract, index=file_counter)
-            meta_dict.update(sub_dict)
-            file_counter+=1
-        if year_month == 'unknown':
-            log.error('No valid HDF5 file(s) fund in the directory %s' % top)
-            log.warning('Make sure to use the --h5-name H5_NAME  option to select  the hdf5 file or directory containing multiple hdf5 files')
-            return None
-           
-    else:
-        log.error('No valid HDF5 file(s) fund')
-        return None
-
-    df = pd.DataFrame.from_dict(meta_dict, orient='index', columns=('value', 'unit'))
-    return df.to_markdown(tablefmt='grid'), year_month, pi_name
-
-def extract_dict(fname, list_to_extract, index=0):
-
-    mp = meta.read_meta.Hdf5MetadataReader(fname)
-    meta_data = mp.readMetadata()
-    mp.close()
-
-    start_date     = '/process/acquisition/start_date'
-    experimenter   = '/measurement/sample/experimenter/name'
-    full_file_name = '/measurement/sample/file/full_name'
-
-    try: 
-        dt = datetime.datetime.strptime(meta_data[start_date][0], "%Y-%m-%dT%H:%M:%S%z")
-        year_month = str(dt.year) + '-' + '{:02d}'.format(dt.month)
-    except ValueError:
-        log.error("The start date information is missing from the hdf file %s. Error (2020-01)." % fname)
-        year_month = '2020-01'
-    except TypeError:
-        log.error("The start date information is missing from the hdf file %s. Error (2020-02)." % fname)
-        year_month = '2020-02'
-    try:
-        pi_name = meta_data[experimenter][0]
-    except KeyError:
-        log.error("The experimenter name is missing from the hdf file %s." % fname)
-        pi_name = 'Unknown'
-    try:    
-        # compact full_file_name to file name only as original data collection directory may have changed
-        meta_data[full_file_name][0] = os.path.basename(meta_data[full_file_name][0])
-    except KeyError:
-        log.error("The full file name is missing from the hdf file %s." % fname)
-
-    sub_dict = {(('%3.3d' % index) +'_' + k):v for k, v in meta_data.items() if k in list_to_extract}
-
-    return sub_dict, year_month, pi_name
 
 def show_entry(meta_dict, entry):
     error = 0


### PR DESCRIPTION
### Summary

Four small, focused commits:

1. **Remove unused `docs` subcommand and its dependencies** (`ddda55c`). `meta docs` generated an RST metadata table for sphinx/readthedocs. Nobody was using it, and it pulled in `tabulate`, `dxchange`, and `scipy` (the latter two aren't imported anywhere in `src/` at all). The command, its helpers in `utils.py` (`create_rst_file`, `extract_rst_meta`, `extract_dict`, `add_header`, `add_title`, `add_decorator`), those imports, and the corresponding README section and dependency list entries all go.

2. **Add `-h` help alias, `--path` alias for `show`, fix directory handling** (`acd2fb1`).
   - `-h` now works everywhere as an alias for `--help` (via a shared `CONTEXT_SETTINGS`).
   - `show` gains `--path` as an alias for `--file-name`, since it's the only subcommand that accepts either a file or a folder — the name `--file-name` reads badly in the folder case.
   - `show` on a directory used to crash with `NameError: args`. The Click migration in `e54e9bc` left one stale `args.file_name` reference in the directory branch. Fixed to use `file_name`.
   - `tree` and `set` now warn cleanly if given a directory, instead of silently doing nothing (`tree`) or falling through the "file does not exist" branch (`set`).

3. **Fix `set` subcommand broken since the Click migration** (`ce55048`). Two bugs from the same `e54e9bc` (2024-06-07) commit:
   - The three `@click.option` decorators declared `--file-name`, `--key`, `--value`, but the function signature was `def set(file_name):`. Click would raise `TypeError` on every invocation.
   - `--value` came in as a string (no `type=`), but `utils.swap` writes into a float HDF5 dataset. Added `type=float` so Click rejects non-numeric input up front.

4. **Add `meta rec` subcommand to extract the tomocupy command from `_rec.h5`** (`f8d602c`). tomocupy stores the full reconstruction invocation as a `command` string attribute on `/exchange/data` of every `_rec.h5` it produces (see `tomocupy/src/tomocupy/dataio/writer.py`). For `tiff` and `h5sino` outputs it also writes a sidecar `rec_line.txt` / `_line.txt`, but for `h5nolinks` the command was only reachable via `h5dump`. This new subcommand exposes it:
   - `meta rec --file-name X_rec.h5` prints the command to stdout.
   - `meta rec --file-name X_rec.h5 --save` also writes a sibling `X_rec_line.txt` matching the sidecar convention.
   - Given a directory, iterates over every `.h5` / `.hdf` / `.hdf5` file, logs a header per file, and skips (with a warning) any file that has no `/exchange/data` or no `command` attribute — so raw scans and older recs surface a clear message and no sidecar is written for them.
   - `--path` is exposed as an alias for `--file-name`, matching `show`'s convention for folder-capable commands.

### Behavior changes worth noting

- **`meta docs` is removed.** Users who called it will see `Error: No such command 'docs'`.
- **`tabulate`, `dxchange`, `scipy` are dropped from `requirements.txt`.** `dxchange` and `scipy` weren't imported anywhere in `src/`; `tabulate` was only needed for `pd.to_markdown()` in the docs path. If any downstream user relied on meta-cli's install pulling these in as a side effect, they'll need to install them explicitly.
- **`meta set` now works.** It was raising `TypeError` on every call since June 2024, so nobody could have relied on the old behavior.
- **`meta tree` and `meta set` now warn on a directory** instead of silently doing nothing / crashing.

### Test plan

Verified manually against a 2-BM session with ~150 mixed raw and `_rec.h5` files at `/data2/2BM/2026-07-Li-1014288{,_rec}/`:

- [x] `meta -h`, `meta show -h`, etc. all show help (`-h` alias).
- [x] `meta show --file-name X.h5` — single file, prints metadata.
- [x] `meta show --path X.h5` — alias works.
- [x] `meta show --path <dir>/` — the directory branch that used to crash now iterates over the folder.
- [x] `meta tree --file-name <dir>/` — warns and exits.
- [x] `meta set --file-name <dir>/` — warns and exits.
- [x] `meta rec --file-name X_rec.h5` — prints the tomocupy command.
- [x] `meta rec --file-name X_rec.h5 --save` — writes `X_rec_line.txt` alongside the input.
- [x] `meta rec --file-name X.h5` (raw file) — warns cleanly, no sidecar written.
- [x] `meta rec --path <dir>/` — iterates, prints command per rec file, warns per raw file, no sidecars in raw case.

### Commits

```
f8d602c Add meta rec subcommand to extract the tomocupy command from _rec.h5
ce55048 Fix set subcommand broken since the Click migration
acd2fb1 Add -h help alias, --path alias for show, and fix directory handling
ddda55c Remove unused docs subcommand and its dependencies
```
