### PR TITLE
Update README and api docs to match current CLI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,12 +53,16 @@ To view the meta data contained in a generic hdf file:
 
 ::
 
-    $ meta show --file-name data/base_file_name_001.h5 
+    $ meta show --file-name data/base_file_name_001.h5
 
 
 .. image:: docs/source/img/meta_show.png
     :width: 40%
     :align: center
+
+``--path`` is an alias for ``--file-name`` and reads more naturally when the argument is a directory. Both accept either a single file or a directory of hdf files; when a directory is given, ``meta show`` iterates over every ``.h5`` / ``.hdf`` / ``.hdf5`` file it contains::
+
+    $ meta show --path data/
 
 View a subset meta data
 -----------------------
@@ -79,20 +83,31 @@ To replace the value of an entry:
 
     $ meta set --file-name data/base_file_name_001.h5 --key /process/acquisition/rotation/rotation_start --value 10
 
-
-to list of all available options::
-
-    $ meta  -h
+.. note::
+    ``meta tree`` and ``meta set`` operate on a single hdf file. If you pass a directory to ``--file-name`` they warn and exit; use ``meta show`` (or ``meta rec``) for folder input.
 
 
-Configuration File
-------------------
+Show the tomocupy reconstruction command
+----------------------------------------
 
-meta parameters are stored in **meta.conf**. You can create a template with::
+`tomocupy <https://github.com/tomography/tomocupy>`_ stores the reconstruction command line as a ``command`` string attribute on ``/exchange/data`` of every ``_rec.h5`` file. To print it back out::
 
-    $ meta init
+    $ meta rec --file-name data/base_file_name_001_rec.h5
 
-**meta.conf** is constantly updated to keep track of the last stored parameters, as initalized by **init** or modified by setting a new option value. For example to re-run the last meta with identical --file-name parameters used before just use::
+Add ``--save`` to also write a sibling ``base_file_name_001_rec_line.txt`` sidecar next to the input, matching what the ``tiff`` and ``h5sino`` tomocupy formats already produce::
 
-    $ meta docs
+    $ meta rec --file-name data/base_file_name_001_rec.h5 --save
 
+Like ``meta show``, ``meta rec`` accepts a directory (via ``--file-name`` or the ``--path`` alias). It iterates over every hdf file in the folder; files that are not tomocupy rec files (raw scans, or older rec files that pre-date the ``command`` attribute) surface a clear warning and get no sidecar::
+
+    $ meta rec --path data/reconstructed/ --save
+
+
+Help
+----
+
+Both ``-h`` and ``--help`` work on the top-level command and on every subcommand::
+
+    $ meta -h
+    $ meta show -h
+    $ meta rec -h

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -28,8 +28,11 @@ Dependencies
 ------------
 
 - `meta <https://github.com/xray-imaging/meta.git>`_
-- pandas => ``conda install pandas``
-- tabulate => ``conda install tabulate``
+- scikit-build
+- click
+- h5py
+- numpy
+- pandas
 
 
 Usage
@@ -42,7 +45,7 @@ To view the data tree contained in a generic hdf file:
 
 ::
 
-    $ meta tree --file-name data/base_file_name_001.h5 
+    $ meta tree --file-name data/base_file_name_001.h5
 
 .. image:: img/meta_tree.png
     :width: 40%
@@ -56,12 +59,16 @@ To view the meta data contained in a generic hdf file:
 
 ::
 
-    $ meta show --file-name data/base_file_name_001.h5 
+    $ meta show --file-name data/base_file_name_001.h5
 
 
 .. image:: img/meta_show.png
     :width: 40%
     :align: center
+
+``--path`` is an alias for ``--file-name`` and reads more naturally when the argument is a directory. Both accept either a single file or a directory of hdf files; when a directory is given, ``meta show`` iterates over every ``.h5`` / ``.hdf`` / ``.hdf5`` file it contains::
+
+    $ meta show --path data/
 
 View a subset meta data
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -82,54 +89,34 @@ To replace the value of an entry:
 
     $ meta set --file-name data/base_file_name_001.h5 --key /process/acquisition/rotation/rotation_start --value 10
 
-
-Meta data rst table
-~~~~~~~~~~~~~~~~~~~
-
-To generate a meta data rst table compatible with sphinx/readthedocs::
-
-    $ meta docs --file-name data/base_file_name_001.h5 
-    2022-02-09 12:30:16,983 - Please copy/paste the content of ./log_2020-05.rst in your rst docs file
+.. note::
+   ``meta tree`` and ``meta set`` operate on a single hdf file. If you pass a directory to ``--file-name`` they warn and exit; use ``meta show`` (or ``meta rec``) for folder input.
 
 
-The content of the generated rst file will publish in a sphinx/readthedocs document as:
+Show the tomocupy reconstruction command
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**2022-05**
+`tomocupy <https://github.com/tomography/tomocupy>`_ stores the reconstruction command line as a ``command`` string attribute on ``/exchange/data`` of every ``_rec.h5`` file. To print it back out::
 
-**decarlo**
+    $ meta rec --file-name data/base_file_name_001_rec.h5
 
-+--------------------------------------------------------+--------------------+--------+
-|                                                        | value              | unit   |
-+========================================================+====================+========+
-|     /measurement/instrument/monochromator/energy       | 30.0               | keV    |
-+--------------------------------------------------------+--------------------+--------+
-|     /measurement/instrument/sample_motor_stack/setup/x | 0.0                | mm     |
-+--------------------------------------------------------+--------------------+--------+
-|     /measurement/instrument/sample_motor_stack/setup/y | 0.4000116247000278 | mm     |
-+--------------------------------------------------------+--------------------+--------+
-|     /measurement/sample/experimenter/email             | decarlof@gmail.com |        |
-+--------------------------------------------------------+--------------------+--------+
+Add ``--save`` to also write a sibling ``base_file_name_001_rec_line.txt`` sidecar next to the input, matching what the ``tiff`` and ``h5sino`` tomocupy formats already produce::
+
+    $ meta rec --file-name data/base_file_name_001_rec.h5 --save
+
+Like ``meta show``, ``meta rec`` accepts a directory (via ``--file-name`` or the ``--path`` alias). It iterates over every hdf file in the folder; files that are not tomocupy rec files (raw scans, or older rec files that pre-date the ``command`` attribute) surface a clear warning and get no sidecar::
+
+    $ meta rec --path data/reconstructed/ --save
 
 
-.. note:: 
-   when using the **docs** option --file-name can be also a folder, e.g. --file-name data/ in this case all hdf files in the folder will be processed.
+Help
+~~~~
 
+Both ``-h`` and ``--help`` work on the top-level command and on every subcommand::
 
-to list of all available options::
-
-    $ meta  -h
-
-
-Configuration File
-~~~~~~~~~~~~~~~~~~
-
-meta parameters are stored in **meta.conf**. You can create a template with::
-
-    $ meta init
-
-**meta.conf** is constantly updated to keep track of the last stored parameters, as initalized by **init** or modified by setting a new option value. For example to re-run the last meta with identical --file-name parameters used before just use::
-
-    $ meta docs
+    $ meta -h
+    $ meta show -h
+    $ meta rec -h
 
 
 


### PR DESCRIPTION
### Summary

Documentation-only follow-up to the recent CLI changes. `README.rst` and `docs/source/api.rst` were both out of sync with what `meta` actually does: they promised subcommands that no longer exist (`meta init`, `meta docs`), missed the new `meta rec`, and didn't mention the `--path` alias
, folder input on `meta show`, the directory guards on `meta tree` / `meta set`, or that `-h` works everywhere.

### Changes

- Drop the stale "Configuration File" section that referenced `meta init` and `meta docs` (both removed).
- Drop the "Meta data rst table" section from `docs/source/api.rst` (was documenting the removed `meta docs` command, including a copy of its example output).
- Document `--path` as an alias for `--file-name` on `meta show`, and note that `meta show` accepts either a single hdf file or a directory of hdf files (iterating over every `.h5` / `.hdf` / `.hdf5` it contains).
- Add a "Show the tomocupy reconstruction command" section documenting the new `meta rec` subcommand: single-file usage, `--save` to write a sibling `<basename>_line.txt` sidecar (mirroring what `tiff` and `h5sino` tomocupy formats produce), and folder mode which skips non-rec files with
 a clear warning.
- Add a note that `meta tree` and `meta set` operate on a single hdf file and now warn cleanly if passed a directory.
- Add a "Help" section noting that `-h` works everywhere as an alias for `--help`.
- Sync `docs/source/api.rst`'s dependency list with `envs/requirements.txt` — it was still listing only `pandas` and `tabulate` even though `tabulate` was removed from the project (and the actual runtime deps are `scikit-build`, `click`, `h5py`, `numpy`, `pandas`).

### No behavior changes

Pure documentation update. No code, tests, or dependency changes.

### Test plan

- [x] Rendered `README.rst` locally to confirm sections look right.
- [x] Rendered `docs/source/api.rst` locally to confirm sections look right.
- [x] Every documented invocation (`meta show`, `meta show --path`, `meta show --path <dir>/`, `meta tree`, `meta set`, `meta rec --file-name`, `meta rec --file-name ... --save`, `meta rec --path <dir>/`, `meta -h`, `meta rec -h`) exercised against a real 2-BM dataset in `01_smoke_test_m
eta_cli.sh`.

### Commit

```
a978b18 Update README and api docs for the new/removed subcommands
```
